### PR TITLE
fix login check, test for data-reader-logged-in body attribute

### DIFF
--- a/edubasedl.py
+++ b/edubasedl.py
@@ -94,11 +94,10 @@ async def main(args):
             await page.click('button[type="submit"]')
             await asyncio.sleep(3)
 
-            body_text = await page.locator("body").inner_text()
-            if (
-                "An account with the credentials you entered does not exist."
-                in body_text
-            ):
+            body = page.locator("body")
+            is_logged_in = await body.get_attribute('data-reader-logged-in')
+
+            if is_logged_in != 'true':
                 print("[!] Invalid credentials")
                 return
 


### PR DESCRIPTION
Hi and first of all, thanks for your effort to create this software!

While using it, i noticed the auth check always succeeds, which threw me in the wrong direction, therefore i fixed it.

**how to reproduce**
```shell
root@72df2af1fe9e:/code# python edubasedl.py -u fake -p fake
[edubasedl]
[*] Logging in
[+] Login successful
[*] Searching for books
[!] There was an error while searching for books
Page.wait_for_selector: Timeout 30000ms exceeded.
Call log:
  - waiting for locator("#libraryItems li") to be visible
```

## Tests

**with wrong credentials**
```shell
root@72df2af1fe9e:/code# python edubasedl.py -u fake -p fake
[edubasedl]
[*] Logging in
[!] Invalid credentials
```

**with working credentials**
```shell
root@72df2af1fe9e:/code# python edubasedl.py -u 'xx' -p 'xxx'
[edubasedl]
[*] Logging in
[+] Login successful
[*] Searching for books
[+] Got a total of 13 books
...
```